### PR TITLE
feat: 🎸 修 moblie 跑版，banner 包成元件

### DIFF
--- a/src/assets/scss/_components.scss
+++ b/src/assets/scss/_components.scss
@@ -1,4 +1,5 @@
 $font-display-base: 72px;
+$font-display-size5: 70px;
 $font-display-size4: 90px;
 $font-display-size3: 120px;
 $font-display-size2: $font-display-size3 * 2;
@@ -13,7 +14,12 @@ $font-display-2xl: calc($font-display-size3 + 5.5vw);
   .font-lato {
     @apply font-display font-bold;
   }
-  // 預設4級大標題font-weight-900 大小120px
+  // 預設5級大標題font-weight-900 大小70px
+  .font-lato-display5 {
+    @apply font-display font-black leading-display;
+    font-size: $font-display-size5;
+  }
+  // 預設4級大標題font-weight-900 大小90px
   .font-lato-display4 {
     @apply font-display font-black leading-display;
     font-size: $font-display-size4;
@@ -61,8 +67,12 @@ $font-display-2xl: calc($font-display-size3 + 5.5vw);
   // 關於我們頁面-背景透框字體隨螢幕縮放自適應，letter-spacing對應文字-4%
   .display-title-back {
     @apply font-display font-black leading-display;
-    font-size: calc($font-display-base + 1vw);
+    font-size: calc(44px + 5vw);
     letter-spacing: calc(calc($font-display-base + 1vw) * -0.04);
+    @screen sm {
+      font-size: calc($font-display-base + 1vw);
+      letter-spacing: calc(calc($font-display-base + 1vw) * -0.04);
+    }
     @screen md {
       font-size: calc($font-display-base + 2vw);
       letter-spacing: calc(calc($font-display-base + 2vw) * -0.04);
@@ -76,7 +86,7 @@ $font-display-2xl: calc($font-display-size3 + 5.5vw);
       letter-spacing: calc($font-display-m * -0.04);
     }
     @screen 2xl {
-      font-size: calc($font-display-m + 2.5vw);
+      font-size: calc($font-display-m + 1.5vw);
       letter-spacing: calc($font-display-m * -0.04);
     }
   }

--- a/src/components/custom/BannerComponent.vue
+++ b/src/components/custom/BannerComponent.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="container pb-14">
+    <h2 class="relative font-display display-title-back font-black flex flex-col leading-[.8]">
+      <span class="text-stroke-light">DISCOVER</span>
+      <span>
+        <slot name="mainTitle">CONCERTS</slot>
+      </span>
+      <span class="text-stroke-light">NOW</span>
+      <Input
+        :placeholder="propPlaceholder"
+        class="hidden sm:block absolute pd-4 xl:p-6 lg:text-base bottom-0 right-0 w-[20rem] md:w-[26rem] lg:w-[36rem] xl:w-[46rem] bg-black-0 box-shadow-light1-hover focus:text-black-60 focus-visible:box-shadow-light1-hover focus-visible:outline-0 hover:box-shadow-light1-hover" />
+      <Input
+        :placeholder="propPlaceholder"
+        class="sm:hidden w-fill p-4 mt-6 bg-black-0 box-shadow-light1-hover focus:text-black-60 focus-visible:box-shadow-light1-hover focus-visible:outline-0 hover:box-shadow-light1-hover" />
+    </h2>
+  </div>
+</template>
+
+<script setup>
+import { Input } from '@/components/ui/input';
+</script>
+
+<script>
+export default {
+  props: ['propPlaceholder'],
+};
+</script>

--- a/src/components/custom/TitleComponent.vue
+++ b/src/components/custom/TitleComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="pt-[150px] relative">
-    <span class="font-lato-display4 sm:font-lato-display3 text-stroke-title z-[-1]">
+    <span class="font-lato-display5 sm:font-lato-display4 md:font-lato-display3 text-stroke-title z-[-1]">
       <slot name="subTitle">CONCERT</slot>
     </span>
     <h2 class="relative drop-shadow-light text-3xl lg:text-4xl">
@@ -8,7 +8,3 @@
     </h2>
   </div>
 </template>
-
-<script>
-export default {};
-</script>

--- a/src/components/ui/button/index.js
+++ b/src/components/ui/button/index.js
@@ -8,13 +8,13 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        'white-outline': 'bg-transparent border-2 hover:bg-primary-foreground hover:text-primary hover:box-shadow-light1-hover', // 設計稿按鈕樣式
-        'white-blur': 'bg-transparent border-2 box-shadow-light2 hover:bg-primary-foreground hover:text-primary hover:box-shadow-light2-hover', // 設計稿按鈕樣式
-        'tiffany-outline': 'border-2 border-tiffany text-tiffany hover:bg-tiffany hover:text-primary hover:box-shadow-tiffany-outline-hover',
-        'tiffany-blur': 'border-2 border-tiffany text-tiffany box-shadow-light2 hover:bg-tiffany hover:text-primary hover:box-shadow-tiffany-blur-hover',
+        'white-outline': 'bg-transparent border-[3px] hover:bg-primary-foreground hover:text-primary hover:box-shadow-light1-hover', // 設計稿按鈕樣式
+        'white-blur': 'bg-transparent border-[3px] box-shadow-light2 hover:bg-primary-foreground hover:text-primary hover:box-shadow-light2-hover', // 設計稿按鈕樣式
+        'tiffany-outline': 'border-[3px] border-tiffany text-tiffany hover:bg-tiffany hover:text-primary hover:box-shadow-tiffany-outline-hover',
+        'tiffany-blur': 'border-[3px] border-tiffany text-tiffany box-shadow-light2 hover:bg-tiffany hover:text-primary hover:box-shadow-tiffany-blur-hover',
         'tiffany-fill': 'bg-tiffany text-primary',
-        'pink-outline': 'border-2 border-pink text-pink hover:bg-pink hover:text-primary hover:box-shadow-pink-outline-hover',
-        'pink-blur': 'border-2 border-pink text-pink box-shadow-pink-blur hover:bg-pink hover:text-primary hover:box-shadow-pink-blur-hover',
+        'pink-outline': 'border-[3px] border-pink text-pink hover:bg-pink hover:text-primary hover:box-shadow-pink-outline-hover',
+        'pink-blur': 'border-[3px] border-pink text-pink box-shadow-pink-blur hover:bg-pink hover:text-primary hover:box-shadow-pink-blur-hover',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',

--- a/src/views/front/ConcertSingleView.vue
+++ b/src/views/front/ConcertSingleView.vue
@@ -51,7 +51,7 @@
         <img :src="concerts[0].cover_urls.horizontal" alt="" class="mx-0 rounded-[40px] w-[700px] h-[400px] object-cover hidden 2xl:block" />
       </div>
       <div class="flex flex-col lg:flex-row gap-4 lg:gap-0 lg:justify-around">
-        <div class="w-[80%] md:w-[60%] lg:w-[40%] mx-auto bg-shadow-trans-text rounded-[40px] flex items-center justify-center py-4 lg:py-0 relative">
+        <div class="w-[100%] sm:w-[80%] md:w-[60%] lg:w-[40%] mx-auto bg-shadow-trans-text rounded-[40px] flex flex-col sm:flex-row items-center justify-center py-4 lg:py-0 relative">
           <p class="text-2xl font-bold relative">
             <span class="text-base pr-2 absolute bottom-0 left-[-30%]">D-day</span>
             50 : 12 : 40 : 02
@@ -74,7 +74,7 @@
       <div class="flex flex-col">
         <div class="flex items-center justify-start gap-10 lg:gap-20">
           <div class="text-6xl md:text-[5rem] xl:text-[7rem] text-stroke-light font-bold mb-[-1.5rem] xl:mb-[-2.5rem]">01</div>
-          <div class="flex justify-between items-center mt-6 xl:mt-10 w-[100%]">
+          <div class="flex justify-between items-center mt-6 xl:mt-10 w-[100%] hover:translate-y-[-0.25rem]">
             <h2 class="text-lg md:text-xl lg:text-3xl">
               <a href="" class="py-4">寬宏售票系統</a>
             </h2>
@@ -95,9 +95,9 @@
         <template #subTitle>SONGS</template>
         <template #mainTitle>歌單</template>
       </TitleComponent>
-      <div class="tracking-normal text-base bg-shadow-trans-text rounded-[40px] px-8 py-12 flex flex-col items-center mx-auto w-[400px] gap-2">
+      <div class="tracking-normal text-base bg-shadow-trans-text rounded-[40px] px-8 py-12 flex flex-col items-center mx-auto w-auto max-w-[350px] sm:max-w-none sm:w-[400px] lg:w-[450px] gap-2">
         <iframe
-          class="rounded-[20px]"
+          class="rounded-[20px] w-auto max-w-[284px] sm:max-w-none sm:w-[336px]"
           width="336"
           height="189"
           src="https://www.youtube.com/embed/x8G4xrYfWmw?si=EPcB0Nnm8i3rIFAW"
@@ -105,19 +105,7 @@
           frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen></iframe>
-        <!-- 第3版:無'新增曲目'字樣，標題旁新增按鈕 -->
-        <!-- <div class="flex items-center justify-between">
-          <div class="text-xl lg:text-2xl font-bold marquee-container w-[285.5px] mr-4">
-            <div class="marquee-text">Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 </div>
-            <div class="marquee-text">Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 </div>
-            <div class="marquee-text">Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 </div>
-          </div>
-          <button class="px-1 space-x-2 ml-auto border-2 rounded-[50%] w-8 h-8">
-            <font-awesome-icon icon="fa-solid fa-plus" class="text-lg" />
-          </button>
-        </div>
-        <div class="w-full h-[4px] bg-white"></div> -->
-        <div class="text-xl lg:text-2xl font-bold marquee-container w-[336px]">
+        <div class="text-xl lg:text-2xl font-bold marquee-container w-[284px] sm:w-[336px]">
           <div class="marquee-text">Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站</div>
           <div class="marquee-text">Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站</div>
           <div class="marquee-text">Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站 Tom Jones 湯姆瓊斯演唱會 2024 台北站</div>
@@ -132,8 +120,6 @@
           <font-awesome-icon icon="fa-solid fa-plus" class="text-lg" />
           <p>新增曲目</p>
         </button> -->
-        <!-- <div class="w-full h-[4px] bg-white"></div> -->
-        <!-- <div class="w-full h-[1px] bg-white"></div> -->
         <!-- hover:box-shadow-pink-blur-hover -->
         <!-- hover:bg-[var(--tiffany)] hover:text-black hover:font-bold -->
         <ScrollArea class="h-[19rem] w-full pt-4">
@@ -141,8 +127,8 @@
             <div class="text-base flex justify-between items-center bg-trans">
               <div>{{ index + 1 }}</div>
               <!-- (待完成)點擊更換YT嵌入 -->
-              <button class="ml-4 mr-auto py-3">歌曲名稱{{ item }}</button>
-              <div class="flex pr-4 gap-6 h-14">
+              <button class="ml-4 mr-auto py-3 max-w-[110px] sm:max-w-[160px] lg:max-w-[208px] overflow-x-hidden text-nowrap">歌曲名稱{{ item }}</button>
+              <div class="flex pr-4 gap-2 sm:gap-6 h-14">
                 <!-- (待完成)推與倒推按鈕 -->
                 <button class="flex items-center text-sm hover:text-base gap-1 hover:text-[var(--tiffany)] hover:font-bold">
                   <font-awesome-icon icon="fa-solid fa-chevron-up" />
@@ -226,5 +212,8 @@ export default {
 }
 .bg-trans:hover {
   background: rgba(165, 165, 165, 0.1);
+}
+.btn-explore-icon-color:hover svg path {
+  fill: #1e1e1e;
 }
 </style>

--- a/src/views/front/ConcertsView.vue
+++ b/src/views/front/ConcertsView.vue
@@ -1,37 +1,27 @@
 <template>
   <!-- <font-awesome-icon icon="fa-regular fa-bookmark" class="text-xl" style="color:var(--pink)" /> -->
   <!-- <font-awesome-icon icon="fa-solid fa-bookmark" class="text-xl" style="color:var(--pink)" /> -->
-  <section class="container relative pt-20">
-    <div class="grid grid-flow-col pb-10">
-      <h2 class="test text-[3.5rem] font-display sm:text-display-3 font-black flex flex-col leading-[.8]">
-        <span>DISCOVER</span>
-        <span class="text-stroke">CONCERTS</span>
-        <span>NOW</span>
-      </h2>
-      <div class="grid grid-cols-3">
-        <div class="row-start-9 sm:row-start-8 col-start-3 md:col-start-1 -ms-32 sm:-ms-64 lg:-ms-[400px] xl:-ms-[500px] 2xl:-ms-[600px]">
-          <Input
-            placeholder="輸入演唱會名稱"
-            class="bg-black-0 box-shadow-light1-hover focus:text-black-60 focus-visible:box-shadow-light1-hover focus-visible:outline-0 hover:box-shadow-light1-hover" />
-        </div>
-      </div>
-    </div>
-    <main class="space-y-6 lg:space-y-10 pb-20 lg:pb-32 border-b-2 border-black-60">
+  <section class="container relative pt-10">
+    <!-- banner 元件，請在 data 建立變數 bannerInputPlaceholder 並輸入 placeholder 內文字串 -->
+    <BannerComponent :prop-placeholder="bannerInputPlaceholder">
+      <template #mainTitle>CONCERTS</template>
+    </BannerComponent>
+    <main class="space-y-6 lg:space-y-14 pb-20 lg:pb-32 border-b-2 border-black-60">
       <div>
-        <div class="space-y-3 space-x-3 -m-1 p-1">
-          <!-- <Button variant="pink-blur" size="base" class="me-4"> 全部 </Button> -->
+        <div class="space-y-4 space-x-4 space-x-reverse -m-1 p-1">
+          <Button variant="tiffany-outline" size="base" class="me-4"> 全部 </Button>
           <template v-for="time in timeRanges" :key="time">
-            <Button variant="pink-blur" size="base"> {{ time }} </Button>
+            <Button variant="tiffany-outline" size="base"> {{ time }} </Button>
           </template>
         </div>
-        <div class="space-y-3 space-x-3 -m-1 p-1">
-          <!-- <Button variant="tiffany-blur" size="base" class="me-4"> 全部 </Button> -->
+        <div class="space-y-4 space-x-4 space-x-reverse -m-1 p-1">
+          <Button variant="pink-outline" size="base" class="me-4"> 全部 </Button>
           <template v-for="nationality in nationalityRanges" :key="nationality">
-            <Button variant="tiffany-blur" size="base"> {{ nationality }} </Button>
+            <Button variant="pink-outline" size="base"> {{ nationality }} </Button>
           </template>
         </div>
       </div>
-      <ul class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6">
+      <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-6">
         <li v-for="concert in concerts" :key="concert.id">
           <!-- <Card class="border-black-60">
             <CardHeader class="rounded-t-2xl space-y-0 p-0">
@@ -57,8 +47,8 @@
               <img :src="concert.cover_urls.square" :alt="concert.title" class="aspect-square rounded-t-2xl object-cover" />
               <CardDescription class="border-x-2 pt-6 px-6 border-black-60 flex justify-between align-top">
                 <div>
-                  <p class="text-tiny">{{ concert.holding_time.substring(0, 10) }}</p>
-                  <CardTitle class="pt-1 text-base sm:text-lg text-white h-[7rem] lg:h-[6rem]">{{ concert.title }}</CardTitle>
+                  <p class="text-tiny lg:text-sm">{{ concert.holding_time.substring(0, 10) }}</p>
+                  <CardTitle class="pt-1 text-base lg:text-lg text-white h-[2.4rem] sm:h-[4rem] lg:h-[6rem]">{{ concert.title }}</CardTitle>
                 </div>
                 <button class="mb-auto">
                   <font-awesome-icon icon="fa-regular fa-bookmark" class="text-3xl ml-4" style="color: var(--pink)" />
@@ -100,10 +90,10 @@
 </template>
 <script setup>
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Pagination, PaginationEllipsis, PaginationFirst, PaginationLast, PaginationList, PaginationListItem, PaginationNext, PaginationPrev } from '@/components/ui/pagination';
 import { ArrowRight } from 'lucide-vue-next';
+import BannerComponent from '@/components/custom/BannerComponent.vue';
 </script>
 <script>
 import { mapActions, mapState } from 'pinia';
@@ -111,8 +101,9 @@ import { useConcertsStore } from '@/stores/concerts';
 export default {
   data() {
     return {
-      timeRanges: ['全部', '本日', '本月', '本週'],
-      nationalityRanges: ['全部', '臺灣', '日本', '韓國', '歐美', '其他'],
+      bannerInputPlaceholder: '請輸入演唱會名稱',
+      timeRanges: ['本日', '本月', '本週'],
+      nationalityRanges: ['臺灣', '日本', '韓國', '歐美', '其他'],
     };
   },
   inject: ['http', 'path'],


### PR DESCRIPTION
開會時提到的跑版都修好了

- _components.scss 新增 $font-display-size5 跟調整 display-title-back：縮小最小寬度時的英文標題字，避免出現X軸
- banner 包成元件，樣式改動(便原本的相反)更凸顯重點文字
- 按鈕寬度 border-2 -> border-[3px] (不好意思一直改，為了畫面RRR)

使用 banner 元件可以參考演唱會總覽頁 ConcertsView.vue
要在 data 建立變數 bannerInputPlaceholder 並輸入 placeholder 內文字串
使用說明書：
```html
</template>
  <BannerComponent :prop-placeholder="bannerInputPlaceholder">
    <template #mainTitle>/*輸入英文標題字*/</template>
  </BannerComponent>
</template>

<script setup>
import BannerComponent from '@/components/custom/BannerComponent.vue';
</script>

<script>
export default {
  data() {
    return {
      bannerInputPlaceholder: '/*placeholder要放的文字*/',
    }
  }
}
</script>
```