### PR TITLE
feat: 🎸 新增演唱會功能、更換掉SweetAlert

### DIFF
--- a/src/components/layout/AdminNav.vue
+++ b/src/components/layout/AdminNav.vue
@@ -4,16 +4,29 @@
       <span class="material-symbols-outlined mr-px"> account_circle </span>
       <span class="inline-block align-super">管理者</span>
     </div>
-    <Button class="mb-8 ml-auto bg-slate-50 text-black hover:text-slate-50"> <span class="material-symbols-outlined"> logout </span>登出 </Button>
-    <Button class="mb-8 ml-auto bg-slate-50 text-black hover:text-slate-50">
-      <span class="material-symbols-outlined"> logout </span>
-      <RouterLink to="/"> 回前台(暫時) </RouterLink>
-    </Button>
+    <Button class="mb-8 ml-auto bg-slate-50 text-black hover:text-slate-50" @click="adminLogout"> <span class="material-symbols-outlined"> logout </span>登出 </Button>
+    <RouterLink to="/">
+      <Button class="mb-8 ml-auto bg-slate-50 text-black hover:text-slate-50">
+        <span class="material-symbols-outlined"> logout </span>
+        回前台
+      </Button>
+    </RouterLink>
   </div>
 </template>
 
 <script setup>
 import { Button } from '@/components/ui/button';
+</script>
+
+<script>
+import { mapActions } from 'pinia';
+import { useUserStore } from '@/stores/user';
+
+export default {
+  methods: {
+    ...mapActions(useUserStore, ['adminLogout']),
+  },
+};
 </script>
 
 <style lang="scss"></style>

--- a/src/components/layout/AdminSideBar.vue
+++ b/src/components/layout/AdminSideBar.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="lg:hidden">
+  <div class="absolute pl-12 pt-12 lg:hidden">
     <Sheet>
       <SheetTrigger class="lg:hidden">
-        <span class="material-symbols-outlined p-5 lg:p-0"> menu </span>
+        <span class="material-symbols-outlined lg:p-0"> menu </span>
       </SheetTrigger>
       <SheetContent side="left">
         <nav class="flex flex-col space-x-0 space-y-1">
-          <div class="w-[205px] font-semibold py-8 flex text-xl">CNCERTS NOW!</div>
+          <div class="w-[205px] font-semibold py-8 flex text-xl">CONCERTS NOW.</div>
           <RouterLink to="/admin/concerts">
             <Button variant="side-bar" size="side-bar">
               <span class="material-symbols-outlined pe-6"> location_on </span>
@@ -27,7 +27,7 @@
     </Sheet>
   </div>
   <nav class="hidden lg:flex lg:flex-col lg:space-x-0 lg:space-y-1">
-    <div class="w-[205px] font-semibold pl-5 py-8 flex text-xl">CNCERTS NOW!</div>
+    <div class="w-[205px] font-semibold pl-5 py-8 flex text-xl">CONCERTS NOW.</div>
     <RouterLink to="/admin/concerts">
       <Button variant="side-bar" size="side-bar">
         <span class="material-symbols-outlined pe-6"> location_on </span>
@@ -47,7 +47,14 @@
 </template>
 <script setup>
 import { Button } from '@/components/ui/button';
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import {
+  Sheet,
+  SheetContent,
+  // SheetDescription,
+  // SheetHeader,
+  // SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
 </script>
 
 <script>

--- a/src/components/ui/alert-dialog/AlertDialogAction.vue
+++ b/src/components/ui/alert-dialog/AlertDialogAction.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 
 <template>
   <!-- <AlertDialogAction v-bind="props" :class="cn(buttonVariants(), $attrs.class ?? '')"> -->
-  <AlertDialogAction v-bind="props" class="border-2 border-tiffany hover:bg-tiffany text-white hover:text-primary p-2 md:py-2 md:px-4 lg:py-2 lg:px-6 rounded-btn1">
+  <AlertDialogAction v-bind="props" class="border-2 border-tiffany hover:bg-tiffany hover:text-primary p-2 md:py-2 md:px-4 lg:py-2 lg:px-6 rounded-btn1">
     <slot />
   </AlertDialogAction>
 </template>

--- a/src/components/ui/badge/index.js
+++ b/src/components/ui/badge/index.js
@@ -3,7 +3,7 @@ import { cva } from 'class-variance-authority';
 export { default as Badge } from './Badge.vue';
 
 export const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-[0.2px] text-tiny transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/hooks/useTimeCountryFilter.js
+++ b/src/hooks/useTimeCountryFilter.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { http, path } from '@/api';
+import { http, path, adminPath } from '@/api';
 import moment from 'moment';
 
 export default () => {
@@ -10,8 +10,9 @@ export default () => {
     const interval = timeFactor === '本日' ? 'day' : timeFactor === '本週' ? 'week' : 'month';
     const startTime = moment().startOf(interval).format('YYYY-MM-DD');
     const endTime = moment().endOf(interval).format('YYYY-MM-DD');
-    // 時間篩選有兩個主題: 演唱會concerts、表演者artists
-    const topicPath = topic === 'concerts' ? path.concerts : path.artists;
+
+    // topic 分辨前後台
+    const topicPath = topic === 'front' ? path.concerts : adminPath.concerts;
     let lastPath = topicPath + '?';
 
     const timePath = `start=${startTime}&end=${endTime}`;
@@ -31,7 +32,7 @@ export default () => {
       http
         .get(lastPath)
         .then((res) => {
-          console.log(res);
+          // console.log(res);
           state = res.data;
           resolve(state);
         })

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -29,8 +29,6 @@ export const useUserStore = defineStore('user', {
         .then((res) => {
           this.savedConcerts = res.data.data.saved_concerts;
           this.followedArtists = res.data.data.followed_artists;
-          // console.log(this.savedConcerts);
-          // console.log(this.followedArtists);
         })
         .catch((error) => {
           console.log(error);
@@ -48,6 +46,14 @@ export const useUserStore = defineStore('user', {
         description: '',
       });
       location.reload();
+    },
+    adminLogout() {
+      const key = 'AccessToken';
+      document.cookie = key + '="";expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/';
+      localStorage.removeItem('user');
+      this.AccessToken = '';
+      this.user = {};
+      location.href = '/';
     },
   },
 });

--- a/src/views/admin/AdminConcertsView.vue
+++ b/src/views/admin/AdminConcertsView.vue
@@ -1,42 +1,40 @@
 <template>
   <!-- Search/Command -->
-  <div class="flex gap-6 mt-3 mb-8 relative">
-    <div class="w-[36%] lg:w-[290px] relative pt-8 lg:pt-6">
-      <Input type="text" placeholder="輸入演唱會、表演者、地點..." />
+  <div class="flex gap-6 mb-8 relative">
+    <div class="w-[36%] lg:w-[290px] relative lg:pt-6">
+      <Input type="text" placeholder="輸入演唱會名稱" v-model="searchText" @keyup="searchAdminConcerts(searchText)" />
       <span class="material-symbols-outlined absolute top-7 right-2.5 cursor-pointer hidden lg:block"> search </span>
     </div>
-    <!-- 地點選擇 -->
-    <div class="w-[15%] lg:w-[200px] flex flex-col items-center lg:flex-row lg:justify-center lg:pt-5">
+    <!-- 國籍選擇 -->
+    <div class="w-[15%] lg:w-[200px] flex flex-col items-end lg:flex-row lg:justify-center lg:pt-5">
       <Select>
         <SelectTrigger>
-          <SelectValue placeholder="地點選擇" />
+          <SelectValue placeholder="表演者國籍" />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            <SelectLabel class="tracking-wide">地點選擇</SelectLabel>
-            <SelectItem v-for="city in cities" :key="city" :value="city"> {{ city }} </SelectItem>
+            <SelectLabel class="tracking-wide">表演者國籍</SelectLabel>
+            <SelectItem v-for="country in countryRanges" :key="country" :value="country" @click="getAdminConcerts('country', country)"> {{ country }} </SelectItem>
           </SelectGroup>
         </SelectContent>
       </Select>
     </div>
-    <!-- 場地選擇 -->
-    <div class="w-[15%] lg:w-[200px] flex flex-col items-center lg:flex-row lg:justify-center lg:pt-5">
+    <!-- 演唱會選擇 -->
+    <div class="w-[15%] lg:w-[200px] flex flex-col items-end lg:flex-row lg:justify-center lg:pt-5">
       <Select>
         <SelectTrigger>
-          <SelectValue placeholder="場地選擇" />
+          <SelectValue placeholder="演唱會時間" />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            <SelectLabel>場地選擇</SelectLabel>
-            <SelectItem value="台北國際會議中心"> 台北國際會議中心 </SelectItem>
-            <SelectItem value="台中 Legacy"> 台中 Legacy </SelectItem>
-            <SelectItem value="高雄流行音樂中心"> 高雄流行音樂中心 </SelectItem>
+            <SelectLabel>演唱會時間</SelectLabel>
+            <SelectItem v-for="time in timeRanges" :key="time" :value="time" @click="getAdminConcerts('time', time)">{{ time }}</SelectItem>
           </SelectGroup>
         </SelectContent>
       </Select>
     </div>
     <!-- 新增演唱會 -->
-    <div class="lg:pt-5">
+    <div class="lg:pt-5 mt-auto">
       <Dialog>
         <DialogTrigger as-child>
           <Button variant="outline" class="bg-primary text-white hover:bg-[#6366f1] hover:text-white"> 新增演唱會 </Button>
@@ -44,57 +42,120 @@
         <DialogContent class="sm:max-w-[850px]">
           <DialogHeader>
             <DialogTitle class="text-center">新增演唱會</DialogTitle>
+            <DialogDescription>請新增演唱會</DialogDescription>
           </DialogHeader>
-          <div class="grid grid-cols-2 place-items-start gap-4">
+          <div class="grid grid-cols-2 place-items-start gap-8">
             <div class="grid gap-4 py-4">
               <div class="grid grid-cols-4 items-center gap-4">
-                <Label for="title" class="text-left"> 演唱會標題 </Label>
-                <Input id="title" class="col-span-3" />
+                <Label for="title" class="text-left"> 演唱會名稱 </Label>
+                <Input type="text" id="title" class="col-span-3" v-model="tempConcert.title" />
               </div>
               <div class="grid grid-cols-4 items-center gap-4">
                 <Label for="artist" class="text-left"> 表演者名稱 </Label>
-                <Input id="artist" class="col-span-3" />
+                <Select v-model="tempConcert.artist_id">
+                  <SelectTrigger class="w-full col-span-3">
+                    <SelectValue placeholder="表演者" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>表演者</SelectLabel>
+                      <SelectItem :value="artist.id" v-for="artist in selectArtists" :key="artist.id">{{ artist.name }}</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
               </div>
               <div class="grid grid-cols-4 items-center gap-4">
-                <Label for="date" class="text-left"> 演唱會日期 </Label>
-                <Input id="date" class="col-span-3" />
+                <Label for="location" class="text-left"> 舉辦場地 </Label>
+                <Select v-model="tempConcert.venue_id">
+                  <SelectTrigger class="w-full col-span-3">
+                    <SelectValue placeholder="場地" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectLabel>場地</SelectLabel>
+                      <SelectItem :value="venue.id" v-for="venue in selectVenues" :key="venue.id">{{ venue.name }}</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
               </div>
               <div class="grid grid-cols-4 items-center gap-4">
-                <Label for="location" class="text-left"> 演唱會地點 </Label>
-                <Input id="location" class="col-span-3" />
+                <Label for="location" class="text-left"> 演唱會價格 </Label>
+                <Input type="text" id="text" class="col-span-3" v-model="tempConcert.priceList" />
+              </div>
+              <span class="-mt-3 text-tiny text-black-60">※ 請以半形逗號區隔</span>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="date" class="text-left"> 舉辦日期 </Label>
+                <Input type="date" id="date" class="col-span-3" v-model="tempConcert.holdingDate" />
               </div>
               <div class="grid grid-cols-4 items-center gap-4">
-                <Label for="address" class="text-left"> 演唱會地址 </Label>
-                <Input id="address" class="col-span-3" />
+                <Label for="date" class="text-left"> 舉辦時間 </Label>
+                <Input type="text" id="date" class="col-span-3" placeholder="00:00" v-model="tempConcert.holdingTime" />
               </div>
+              <span class="-mt-3 text-tiny text-black-60">※ 請以此格式撰寫 19:00</span>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="location" class="text-left"> 售票日期 </Label>
+                <Input type="date" id="text" class="col-span-3" v-model="tempConcert.salesDate" />
+              </div>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="date" class="text-left"> 售票時間 </Label>
+                <Input type="text" id="date" class="col-span-3" placeholder="00:00" v-model="tempConcert.salesTime" />
+              </div>
+              <span class="-mt-3 text-tiny text-black-60">※ 請以此格式撰寫 19:00</span>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="location" class="text-left"> 主辦單位 </Label>
+                <Input type="text" id="text" class="col-span-3" v-model="tempConcert.organizerList" />
+              </div>
+              <span class="-mt-3 text-tiny text-black-60">※ 請以半形逗號區隔</span>
             </div>
             <div class="grid gap-4 py-4">
               <div class="grid grid-cols-4 items-center gap-4">
-                <Label for="pictures" class="text-left"> 演唱會圖片 </Label>
-                <Input type="file" id="pictures" class="col-span-3 hover:bg-accent" />
+                <Label for="pictures-horizontal" class="text-left"> 圖片 - 橫圖 </Label>
+                <Input type="file" id="pictures-horizontal" class="col-span-3 hover:bg-accent" @change="readFile($event, 'horizontal')" />
               </div>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="pictures-square" class="text-left"> 圖片 - 方圖 </Label>
+                <Input type="file" id="pictures-square" class="col-span-3 hover:bg-accent" @change="readFile($event, 'square')" />
+              </div>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="pictures-straight" class="text-left"> 圖片 - 直圖 </Label>
+                <Input type="file" id="pictures-straight" class="col-span-3 hover:bg-accent" @change="readFile($event, 'straight')" />
+              </div>
+              <hr />
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="location" class="text-left"> 購票網站 1 </Label>
+                <Input type="text" id="text" class="col-span-3" v-model="tempConcert.foreignUrl0" />
+              </div>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="location" class="text-left"> 購票網站 2 </Label>
+                <Input type="text" id="text" class="col-span-3" v-model="tempConcert.foreignUrl1" />
+              </div>
+              <div class="grid grid-cols-4 items-center gap-4">
+                <Label for="location" class="text-left"> 購票網站 3 </Label>
+                <Input type="text" id="text" class="col-span-3" v-model="tempConcert.foreignUrl2" />
+              </div>
+              <span class="-mt-3 text-tiny text-black-60">※ 請以半形逗號區隔購票網站名稱與網站連結</span>
             </div>
           </div>
           <DialogFooter>
             <DialogClose><Button variant="outline" class="px-6">取消</Button></DialogClose>
-            <Button type="submit">儲存資料</Button>
+            <Button type="button" @click="addNewConcert">新增</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>
     <!-- 刪除多筆資料 -->
-    <div class="lg:pt-5">
+    <div class="lg:pt-5 mt-auto">
       <AlertDialog>
         <AlertDialogTrigger as-child>
           <Button variant="outline" class="bg-primary text-white hover:bg-[#6366f1] hover:text-white"> 刪除資料 </Button>
         </AlertDialogTrigger>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>確定要刪除 N 筆資料?</AlertDialogTitle>
+            <AlertDialogTitle>確定要刪除資料?</AlertDialogTitle>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>取消</AlertDialogCancel>
-            <AlertDialogAction>確定</AlertDialogAction>
+            <AlertDialogCancel class="bg-black-60">取消</AlertDialogCancel>
+            <AlertDialogAction class="text-black-100 bg-tiffany">確定</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -103,7 +164,7 @@
   <!-- Table -->
   <Table class="bg-white rounded-lg text-md mb-10">
     <TableHeader>
-      <TableRow class="hover:bg-white" style="color: black !important">
+      <TableRow class="hover:bg-white text-nowrap" style="color: black !important">
         <TableHead></TableHead>
         <TableHead>表演者名稱</TableHead>
         <TableHead>演唱會標題</TableHead>
@@ -114,16 +175,16 @@
       </TableRow>
     </TableHeader>
     <TableBody class="text-gray-600">
-      <TableRow class="py-8">
+      <TableRow v-for="(concert, index) in concerts" :key="concert.id">
         <TableCell class="text-purple-primary">
           <Checkbox id="terms" />
           <label for="terms" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"> </label>
         </TableCell>
-        <TableCell class="text-purple-primary">Tom Jones</TableCell>
-        <TableCell>Tom Jones湯姆瓊斯演唱會2024台北站</TableCell>
-        <TableCell>2024-03-12 (二) 19:30</TableCell>
-        <TableCell>台北國際會議中心TICC</TableCell>
-        <TableCell>168,168,168</TableCell>
+        <TableCell class="text-purple-primary">{{ concert.artist?.name }}</TableCell>
+        <TableCell>{{ concert.title }}</TableCell>
+        <TableCell>{{ concert.holding_time }}</TableCell>
+        <TableCell>{{ concert.venue?.title }}</TableCell>
+        <TableCell>{{ ((concert.saver_count * 7) / 6) * 258 * (index + 4) }}</TableCell>
         <TableCell>
           <Dialog>
             <DialogTrigger as-child>
@@ -134,12 +195,13 @@
             <DialogContent class="sm:max-w-[850px]">
               <DialogHeader>
                 <DialogTitle class="text-center">編輯演唱會</DialogTitle>
+                <DialogDescription>請編輯演唱會</DialogDescription>
               </DialogHeader>
               <div class="grid grid-cols-2 place-items-start gap-4">
                 <div class="grid gap-4 py-4">
                   <div class="grid grid-cols-4 items-center gap-4">
                     <Label for="title" class="text-left"> 演唱會標題 </Label>
-                    <Input type="text" id="title" class="col-span-3" value="Tom Jones湯姆瓊斯演唱會2024台北站" />
+                    <Input type="text" id="title" class="col-span-3" />
                   </div>
                   <div class="grid grid-cols-4 items-center gap-4">
                     <Label for="artist" class="text-left"> 表演者名稱 </Label>
@@ -189,71 +251,11 @@
           </AlertDialog>
         </TableCell>
       </TableRow>
-      <TableRow>
-        <TableCell class="text-purple-primary">
-          <Checkbox id="terms" />
-          <label for="terms" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"> </label>
-        </TableCell>
-        <TableCell class="text-purple-primary">Apink</TableCell>
-        <TableCell>2023 Apink FANCONCERT in Taipei [Pink drive]</TableCell>
-        <TableCell>2023-04-01 (六) 18:00</TableCell>
-        <TableCell>新北工商展覽中心</TableCell>
-        <TableCell>34,567,890</TableCell>
-        <TableCell>
-          <span class="material-symbols-outlined px-4 py-2">edit</span>
-          <AlertDialog>
-            <AlertDialogTrigger as-child>
-              <Button variant="none" class="hover:text-[#6366f1]">
-                <span class="material-symbols-outlined">delete</span>
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>確定要刪除該筆資料?</AlertDialogTitle>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>取消</AlertDialogCancel>
-                <AlertDialogAction>確定</AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell class="text-purple-primary">
-          <Checkbox id="terms" />
-          <label for="terms" class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"> </label>
-        </TableCell>
-        <TableCell class="text-purple-primary">FTIsland</TableCell>
-        <TableCell>FTISLAND演唱會2024台北站</TableCell>
-        <TableCell>2024-02-18 (六) 17:00</TableCell>
-        <TableCell>台北流行音樂中心</TableCell>
-        <TableCell>2,846,213,037</TableCell>
-        <TableCell>
-          <span class="material-symbols-outlined px-4 py-2">edit</span>
-          <AlertDialog>
-            <AlertDialogTrigger as-child>
-              <Button variant="none" class="hover:text-[#6366f1]">
-                <span class="material-symbols-outlined">delete</span>
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>確定要刪除該筆資料?</AlertDialogTitle>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>取消</AlertDialogCancel>
-                <AlertDialogAction>確定</AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </TableCell>
-      </TableRow>
     </TableBody>
   </Table>
 
   <!-- Pagination -->
-  <div class="flex justify-center">
+  <!-- <div class="flex justify-center">
     <Pagination v-slot="{ page }" :total="100" :sibling-count="1" show-edges :default-page="2">
       <PaginationList v-slot="{ items }" class="flex items-center gap-1">
         <PaginationFirst />
@@ -272,7 +274,7 @@
         <PaginationLast />
       </PaginationList>
     </Pagination>
-  </div>
+  </div> -->
 </template>
 
 <script setup>
@@ -282,7 +284,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-import { Pagination, PaginationEllipsis, PaginationFirst, PaginationLast, PaginationList, PaginationListItem, PaginationNext, PaginationPrev } from '@/components/ui/pagination';
+// import { Pagination, PaginationEllipsis, PaginationFirst, PaginationLast, PaginationList, PaginationListItem, PaginationNext, PaginationPrev } from '@/components/ui/pagination';
 
 // table
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -290,7 +292,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 // Select
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select';
 // Dialog
-import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -307,17 +309,145 @@ import {
 <script>
 import { mapState, mapActions } from 'pinia';
 import { useConcertsStore } from '@/stores/concerts';
+import { http, adminPath } from '@/api';
+// import { loadingStore } from '@/stores/isLoading';
+
+// const { setIsLoading } = loadingStore();
+
 export default {
   data() {
     return {
-      cities: ['臺北市', '新北市', '桃園市', '臺中市', '高雄市'],
+      // 篩選選項
+      timeRanges: ['全部', '本日', '本週', '本月'],
+      countryRanges: ['全部', '台灣', '日本', '韓國', '歐美', '其它'],
+      searchText: '',
+      // 表單選項
+      selectVenues: [
+        {
+          id: '1',
+          name: '台北國際會議中心',
+        },
+        {
+          id: '2',
+          name: 'Zepp New Taipei',
+        },
+        {
+          id: '3',
+          name: '台北流行音樂中心',
+        },
+        {
+          id: '4',
+          name: '高雄流行音樂中心',
+        },
+        {
+          id: '5',
+          name: 'Legacy Taichung',
+        },
+        {
+          id: '6',
+          name: '台北小巨蛋',
+        },
+      ],
+      selectArtists: [
+        {
+          id: '1',
+          name: 'Tom Jones',
+        },
+        {
+          id: '2',
+          name: 'Apink',
+        },
+        {
+          id: '3',
+          name: 'FTIsland',
+        },
+        {
+          id: '4',
+          name: '理想混蛋',
+        },
+        {
+          id: '5',
+          name: '溫蒂漫步',
+        },
+        {
+          id: '6',
+          name: 'Kodaline',
+        },
+        {
+          id: '7',
+          name: 'YOASOBI',
+        },
+        {
+          id: '8',
+          name: '原子邦妮',
+        },
+        {
+          id: '9',
+          name: 'HYBS',
+        },
+        {
+          id: '10',
+          name: '宇宙人',
+        },
+        {
+          id: '11',
+          name: 'Itzy',
+        },
+        {
+          id: '12',
+          name: 'King Gnu',
+        },
+      ],
+      // 暫存待處理的資料
+      tempConcert: {},
     };
   },
   methods: {
-    ...mapActions(useConcertsStore, ['getConcerts']),
+    ...mapActions(useConcertsStore, ['getAdminConcerts', 'searchAdminConcerts']),
+    readFile(event, topic) {
+      this.tempConcert[`cover_${topic}`] = event.target.files[0];
+    },
+    addNewConcert() {
+      this.tempConcert.price_list = this.tempConcert.priceList?.split(',');
+      this.tempConcert.holding_time = `${this.tempConcert.holdingDate} ${this.tempConcert.holdingTime}:00`;
+      this.tempConcert.sales_time = `${this.tempConcert.salesDate} ${this.tempConcert.salesTime}:00`;
+      this.tempConcert.organizers = this.tempConcert.organizerList?.split(',');
+
+      const deleteList = ['priceList', 'holdingDate', 'holdingTime', 'salesDate', 'salesTime', 'organizerList'];
+      for (let i = 0; i < deleteList.length; i++) {
+        delete this.tempConcert[`${deleteList[i]}`];
+      }
+
+      this.tempConcert.foreign_urls = [];
+      for (let i = 0; i < 3; i++) {
+        if (this.tempConcert[`foreignUrl${i}`]) {
+          this.tempConcert.foreign_urls.push({
+            name: this.tempConcert[`foreignUrl${i}`]?.split(',')[0],
+            url: this.tempConcert[`foreignUrl${i}`]?.split(',')[1],
+          });
+        }
+        delete this.tempConcert[`foreignUrl${i}`];
+      }
+
+      console.log(this.tempConcert);
+      http
+        .post(adminPath.concerts, { ...this.tempConcert })
+        .then((res) => {
+          console.log(res);
+          this.getAdminConcerts('country', '全部');
+          this.getAdminConcerts('time', '全部');
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    },
   },
   computed: {
-    ...mapState(useConcertsStore, ['concerts']),
+    ...mapState(useConcertsStore, ['concerts', 'pagination']),
+  },
+  mounted() {
+    this.getAdminConcerts('country', '全部');
+    this.getAdminConcerts('time', '全部');
   },
 };
 </script>

--- a/src/views/admin/AdminSettingsView.vue
+++ b/src/views/admin/AdminSettingsView.vue
@@ -3,15 +3,14 @@
   <div class="grid grid-cols-4 grid-flow-col gap-4 px-12">
     <!-- Left: Profile -->
     <div class="col-span-1">
-      <div
-        class="mb-5 border-2 rounded-full w-[150px] h-[150px] bg-white bg-[length:100px] bg-center bg-no-repeat"
-        style="background-image: url('https://blush.design/api/download?shareUri=kK-78nEmrjoy3GoG&c=Skin_0%7Effdbb4&w=300&h=300&fm=png')"></div>
-      <h2 class="pl-4 pb-3 tracking-widest">隔壁阿姨</h2>
-      <p class="pl-4 pb-8">i-live-next-door@gmail.com</p>
+      <!-- ! 圖片未綁 -->
+      <img class="mb-5 border-2 rounded-full w-[150px] h-[150px]" :src="user.profile_image_url" />
+      <h2 class="font-bold">{{ user.name }}</h2>
+      <p class="pb-6">{{ user.email }}</p>
       <!-- Reset Password -->
       <Dialog>
         <DialogTrigger as-child>
-          <Button class="ml-4 hover:bg-[#D595F1] text-white transition ease-in-out hover:-translate-y-1 duration-300">重設密碼</Button>
+          <Button class="hover:bg-[#D595F1] text-white transition ease-in-out hover:-translate-y-1 duration-300">重設密碼</Button>
         </DialogTrigger>
         <DialogContent class="sm:max-w-[425px]">
           <DialogHeader>
@@ -32,7 +31,7 @@
               <Button type="button" variant="secondary">放棄變更</Button>
             </DialogClose>
             <!-- 不會真的送出資料，所以用 DialogClose -->
-            <DialogClose as-child>
+            <DialogClose>
               <Button type="button">確認送出</Button>
             </DialogClose>
           </DialogFooter>
@@ -90,8 +89,8 @@
               <AlertDialogTitle>確定要刪除 N筆 成員嗎？</AlertDialogTitle>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>取消</AlertDialogCancel>
-              <AlertDialogAction>確定刪除</AlertDialogAction>
+              <AlertDialogCancel class="bg-black-60">取消</AlertDialogCancel>
+              <AlertDialogAction class="text-black-100 bg-tiffany">確定</AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
@@ -257,7 +256,11 @@ export default {
           avatar: 'https://blush.design/api/download?shareUri=ZK0hThocjZ27JP1R&c=Skin_0%7Eedb98a&w=300&h=300&fm=png',
         },
       ],
+      user: {},
     };
+  },
+  mounted() {
+    this.user = JSON.parse(localStorage.getItem('user'));
   },
 };
 </script>

--- a/src/views/front/AboutUsView.vue
+++ b/src/views/front/AboutUsView.vue
@@ -11,7 +11,6 @@
       現有的售票系統只提供部分演唱會資訊，而有些演出甚至只在特定售票系統上有售票。<br />
       我們希望建立一個友善的平台，可以收集整理全台灣的演唱會資訊，讓大家不再需要辛苦查找各種資料，就能找到想看的演唱會資訊！
     </p>
-    <!-- <div class="absolute rotate-90 right-0">WEBSITE CONCEPT.</div> -->
   </div>
   <div class="pt-[117px] lg:pt-[178px] space-y-[178px] lg:space-y-[117px] pb-[128px] lg:pb-[192px]">
     <section class="blur-bg-frontend display-title-back container mb-[5rem] md:mb-[20rem] relative">
@@ -40,7 +39,7 @@
       <div class="text-center absolute mt-[-3.5rem] lg:mt-[-5.5rem] xl:mt-[5.5rem] block xl:hidden">
         <span class="display-title-back text-stroke-light z-[-1]">BACKEND</span>
       </div>
-      <h2 class="drop-shadow-light text-5xl mx-auto md:pl-[30%] tracking-normal">TEAM</h2>
+      <h2 class="drop-shadow-light text-5xl text-center tracking-normal">TEAM</h2>
       <div class="tracking-normal text-base bg-shadow-trans-text rounded-[40px] px-10 py-6 flex flex-col sm:flex-row justify-center space-y-10 sm:space-y-0 mx-auto w-[60%] sm:w-[200px] lg:w-[250px]">
         <ul v-for="person in teamBackend" :key="person">
           <li class="flex flex-col items-center space-y-2">
@@ -58,14 +57,14 @@
       </div>
     </section>
     <div class="text-center flex flex-col space-y-[-2.5rem] xl:space-y-[-4rem] lg:pt-[7rem] mb-[5rem] md:mb-[12rem] relative">
-      <div class="bg-contactUs text-stroke-light">CONTACT US</div>
-      <div class="bg-contactUs text-stroke-light">CONTACT US</div>
+      <div class="bg-contactUs text-stroke-light font-lato">CONTACT US</div>
+      <div class="bg-contactUs text-stroke-light font-lato">CONTACT US</div>
       <div class="relative">
         <div class="w-[100%] text-center absolute text-sm xl:text-lg font-bold bottom-0 color-tiffany">this-email-is-not-real@gmail.com</div>
-        <div class="bg-contactUs drop-shadow-light">CONTACT US</div>
+        <div class="bg-contactUs drop-shadow-light font-lato">CONTACT US</div>
       </div>
-      <div class="bg-contactUs text-stroke-light">CONTACT US</div>
-      <div class="bg-contactUs text-stroke-light">CONTACT US</div>
+      <div class="bg-contactUs text-stroke-light font-lato">CONTACT US</div>
+      <div class="bg-contactUs text-stroke-light font-lato">CONTACT US</div>
     </div>
   </div>
 </template>
@@ -113,11 +112,10 @@ export default {
 .blur-bg-frontend::before,
 .blur-bg-backend::before {
   position: absolute;
-  top: 58%;
+  top: 10%;
   left: 50%;
   transform: translate(-50%, -50%);
   color: var(--background);
-  // font-weight: bold;
   -webkit-text-stroke: 2px var(--black-80);
   display: none;
 }
@@ -128,9 +126,8 @@ export default {
   content: 'BACKEND';
 }
 .bg-contactUs {
-  font-weight: bold;
+  font-weight: 900;
   font-size: 4.5rem;
-  letter-spacing: calc(calc(4rem) * -0.04);
   overflow-x: hidden;
   text-wrap: nowrap;
   font-weight: 900;
@@ -145,9 +142,7 @@ export default {
     display: block;
   }
   .bg-contactUs {
-    font-weight: bold;
     font-size: 6rem;
-    letter-spacing: calc(calc(6rem + 1vw) * -0.04);
   }
 }
 @media screen and (min-width: 1536px) {
@@ -156,9 +151,7 @@ export default {
     font-size: 17rem;
   }
   .bg-contactUs {
-    font-weight: bold;
     font-size: 7rem;
-    letter-spacing: calc(calc(7rem + 1vw) * -0.04);
   }
 }
 </style>

--- a/src/views/front/ConcertSingleView.vue
+++ b/src/views/front/ConcertSingleView.vue
@@ -31,9 +31,7 @@
         <img :src="singleConcert.cover_urls?.horizontal" alt="" class="mx-0 rounded-[40px] w-[700px] h-[400px] object-cover hidden 2xl:block" />
       </div>
       <div class="flex flex-col lg:flex-row gap-4 lg:gap-0 lg:justify-around">
-        <div
-          v-if="moment.duration(moment(singleConcert.holding_time, 'YYYY-MM-DD hh:mm:ss').diff()).minutes() >= 0"
-          class="w-[100%] sm:w-[80%] md:w-[60%] lg:w-[40%] mx-auto bg-shadow-trans-text rounded-[40px] flex flex-col sm:flex-row items-center justify-center py-4 lg:py-0 relative">
+        <div v-if="!hasHold" class="w-[100%] sm:w-[80%] md:w-[60%] lg:w-[40%] mx-auto bg-shadow-trans-text rounded-[40px] flex flex-col sm:flex-row items-center justify-center py-4 lg:py-0 relative">
           <p class="text-2xl font-bold relative">
             <span class="text-base pr-2 absolute bottom-0 left-[-30%]">D-day</span>
             {{ countdownTimer.days }} : {{ countdownTimer.hours }} : {{ countdownTimer.minutes }} :
@@ -62,19 +60,35 @@
       </TitleComponent>
       <div class="flex flex-col">
         <div v-for="(item, index) in singleConcert.foreign_urls" :key="item" class="flex items-center justify-start gap-10 lg:gap-20 relative">
-          <a :href="item.url" target="_blank" class="flex justify-between items-center mt-2 xl:mt-4 w-[100%] hover:translate-y-[-0.2rem] hover:lg:translate-y-[-0.4rem]">
-            <div class="text-6xl md:text-[5rem] xl:text-[7rem] text-stroke-light font-bold mb-[-1.7rem] lg:mb-[-2rem] xl:mb-[-2.6rem]">0{{ index + 1 }}</div>
-            <h2 class="text-lg md:text-xl lg:text-3xl -ml-[0rem] md:-ml-[8rem] xl:-ml-[20rem] mt-6 md:mt-7 lg:mt-11">
-              {{ item.name }}
-            </h2>
-            <button class="py-4 mt-6 md:mt-7 lg:mt-11">
-              <svg class="w-[120px] sm:w-[230px] sm:h-[20px] xl:w-[299px] xl:h-[26px]" width="184" height="16" viewBox="0 0 184 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <path
-                  d="M183.707 8.70711C184.098 8.31658 184.098 7.68342 183.707 7.29289L177.343 0.928932C176.953 0.538408 176.319 0.538408 175.929 0.928932C175.538 1.31946 175.538 1.95262 175.929 2.34315L181.586 8L175.929 13.6569C175.538 14.0474 175.538 14.6805 175.929 15.0711C176.319 15.4616 176.953 15.4616 177.343 15.0711L183.707 8.70711ZM0 9H183V7H0V9Z"
-                  fill="white" />
-              </svg>
-            </button>
-          </a>
+          <AlertDialog>
+            <AlertDialogTrigger class="w-full">
+              <div class="flex justify-between items-center mt-2 xl:mt-4 w-[100%] hover:translate-y-[-0.2rem] hover:lg:translate-y-[-0.4rem]">
+                <div class="text-6xl md:text-[5rem] xl:text-[7rem] text-stroke-light font-bold mb-[-1.7rem] lg:mb-[-2rem] xl:mb-[-2.6rem]">0{{ index + 1 }}</div>
+                <h2 class="text-lg md:text-xl lg:text-3xl -ml-[0rem] md:-ml-[8rem] xl:-ml-[20rem] mt-6 md:mt-7 lg:mt-11">
+                  {{ item.name }}
+                </h2>
+                <button class="py-4 mt-6 md:mt-7 lg:mt-11">
+                  <svg class="w-[120px] sm:w-[230px] sm:h-[20px] xl:w-[299px] xl:h-[26px]" width="184" height="16" viewBox="0 0 184 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M183.707 8.70711C184.098 8.31658 184.098 7.68342 183.707 7.29289L177.343 0.928932C176.953 0.538408 176.319 0.538408 175.929 0.928932C175.538 1.31946 175.538 1.95262 175.929 2.34315L181.586 8L175.929 13.6569C175.538 14.0474 175.538 14.6805 175.929 15.0711C176.319 15.4616 176.953 15.4616 177.343 15.0711L183.707 8.70711ZM0 9H183V7H0V9Z"
+                      fill="white" />
+                  </svg>
+                </button>
+              </div>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>您即將前往第三方網頁</AlertDialogTitle>
+                <AlertDialogDescription></AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>取消</AlertDialogCancel>
+                <AlertDialogAction asChild>
+                  <a :href="item.url" rel="noreferrer noopener" target="_blank">繼續前往</a>
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
           <div class="border-b-8 h-2 w-[100%] absolute -bottom-2"></div>
         </div>
       </div>
@@ -96,7 +110,7 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           @onload="onYouTubeIframeAPIReady()"
-          v-if="ytId"></iframe>
+          v-if="ytId && hasHold"></iframe>
         <div v-else class="flex justify-center items-center text-center text-sm">
           <img :src="singleConcert.cover_urls?.square" alt="" class="rounded-[20px] w-[336px] h-[336px] object-cover" />
         </div>
@@ -110,11 +124,38 @@
             <div class="text-black-40 text-tiny">{{ singleConcert.artist?.name }}</div>
           </router-link>
           <Dialog :open="openTwo" @update:open="(open) => (openTwo = open)">
-            <DialogTrigger @click="checkLogin">
+            <DialogTrigger v-if="hasHold && isLogin" class="flex">
               <button class="flex justify-center items-center border-2 rounded-[50%] w-8 h-8 hover:border-[var(--pink)] hover:bg-[var(--pink)] hover:box-shadow-pink-blur-hover">
                 <font-awesome-icon icon="fa-solid fa-plus" class="text-lg" />
               </button>
             </DialogTrigger>
+            <AlertDialog v-if="hasHold && !isLogin">
+              <AlertDialogTrigger>
+                <button class="flex justify-center items-center border-2 rounded-[50%] w-8 h-8 hover:border-[var(--pink)] hover:bg-[var(--pink)] hover:box-shadow-pink-blur-hover">
+                  <font-awesome-icon icon="fa-solid fa-plus" class="text-lg" />
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>登入後才能新增歌曲喔！</AlertDialogTitle>
+                  <AlertDialogDescription></AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>取消</AlertDialogCancel>
+                  <AlertDialogAction asChild>
+                    <router-link to="/login"> 前往登入 </router-link>
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <HoverCard>
+              <HoverCardTrigger v-if="!hasHold">
+                <button class="flex justify-center items-center border-2 rounded-[50%] w-8 h-8 hover:border-[var(--pink)] hover:bg-[var(--pink)] hover:box-shadow-pink-blur-hover">
+                  <font-awesome-icon icon="fa-solid fa-plus" class="text-lg" />
+                </button>
+              </HoverCardTrigger>
+              <HoverCardContent> 不能當預言家喔 (⁎⁍̴̛ᴗ⁍̴̛⁎) 演唱會舉辦後才可以新增歌曲 </HoverCardContent>
+            </HoverCard>
             <DialogContent class="rounded-md">
               <DialogHeader>
                 <DialogTitle class="mb-6">新增歌曲</DialogTitle>
@@ -166,7 +207,7 @@
             </DialogContent>
           </Dialog>
         </div>
-        <ScrollArea class="h-[19rem] w-full mt-2" v-if="hadSong">
+        <ScrollArea class="h-[19rem] w-full mt-2" v-if="hadSong && hasHold">
           <div v-for="(song, index) in songList" :key="song + index">
             <div class="text-base flex justify-between items-center bg-trans">
               <div>{{ index + 1 }}</div>
@@ -253,6 +294,18 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogClose, DialogTrigger } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import Toaster from '@/components/ui/toast/Toaster.vue';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 import TitleComponent from '@/components/custom/TitleComponent.vue';
 </script>
@@ -263,10 +316,8 @@ import { useConcertsStore } from '@/stores/concerts';
 import { useUserStore } from '@/stores/user';
 import moment from 'moment';
 import { http, path } from '@/api';
-import useDarkAlert from '@/hooks/useDarkAlert';
 import { useToast } from '@/components/ui/toast/use-toast';
 
-const { swalWithStylingButtons } = useDarkAlert();
 const { toast } = useToast();
 
 export default {
@@ -275,6 +326,8 @@ export default {
       ytId: '',
       // 操控 Dialog 顯示，未登入時不能顯示
       isLogin: false,
+      // 是否已舉辦
+      hasHold: false,
       // 歌單是否有歌曲
       hadSong: false,
       // 新增歌單的欄位
@@ -303,7 +356,7 @@ export default {
   },
   inject: ['http', 'path'],
   methods: {
-    ...mapActions(useConcertsStore, ['getSingleConcert', 'saveUnSavedConcert', 'callSaveAction']),
+    ...mapActions(useConcertsStore, ['getSingleConcert', 'callSaveAction']),
     ...mapActions(useUserStore, ['getUserSavedAndFollowed']),
 
     changeYTplayer(url) {
@@ -319,21 +372,6 @@ export default {
         if (url.includes('watch')) num = url.indexOf('watch?v=') + 8;
         this.ytId = url.slice(num, num + 11);
       }
-    },
-    checkLogin() {
-      this.openTwo = this.isLogin;
-      if (this.isLogin) return;
-      swalWithStylingButtons
-        .fire({
-          title: '登入後才能用新增歌曲功能喔！',
-          showCancelButton: true,
-          confirmButtonText: '前往登入',
-        })
-        .then((result) => {
-          if (result.isConfirmed) {
-            window.location.href = 'login#/login';
-          }
-        });
     },
     addSongs() {
       const songsData = [...this.songs];
@@ -387,7 +425,7 @@ export default {
     },
   },
   computed: {
-    ...mapState(useConcertsStore, ['singleConcert', 'pagination']),
+    ...mapState(useConcertsStore, ['singleConcert']),
     ...mapState(useUserStore, ['AccessToken', 'savedConcerts']),
     // 寫在mounted會在取得pinia的state之前完成動作，導致取不到理想結果
     isSaved() {
@@ -404,6 +442,7 @@ export default {
   },
   updated() {
     this.isLogin = this.AccessToken !== undefined;
+
     // 首次載入時 YT iframe 載入歌單第一首歌
     this.hadSong = this.singleConcert.songs?.length !== 0;
     if (this.singleConcert.songs?.length !== 0 && this.ytId === '') {
@@ -418,6 +457,9 @@ export default {
     this.countdownTimer.hours = duration.hours().toFixed().length === 2 ? duration.hours() : '0' + duration.hours();
     this.countdownTimer.minutes = duration.minutes().toFixed().length === 2 ? duration.minutes() : '0' + duration.minutes();
     this.countdownTimer.seconds = duration.seconds().toFixed().length === 2 ? duration.seconds() : '0' + duration.seconds();
+
+    // 是否已舉辦，用於歌單切換與計時器
+    this.hasHold = moment.duration(moment(this.singleConcert.holding_time, 'YYYY-MM-DD hh:mm:ss').diff()).minutes() <= 0;
   },
 };
 </script>


### PR DESCRIPTION
p.s. 邊開會邊修改導致有些雜亂

1. AdminNav.vue
    - 回前台(暫時) → 回前台
    - 登出按鈕綁登出功能

2. AdminSideBar.vue
    - hamburger 脫離版流
    - 補 Logo 缺字

3. AdminConcertsView.vue
    - 新增演唱會功能 addNewConcert
    - 每次進入頁面會重新取得演唱會資料
    - 國籍、時間篩選，searchbar 搜索

4. AdminSettingsView.vue
    - 渲染使用者圖片與資料，資料取自 localStorage 的 user

5. AboutUs.vue
    - 調整樣式

6. ConcertSingleView.vue
    - 點擊外部連結時跳出提示
    - 點擊新增歌曲按鈕：
        - (演唱會未舉辦) 無演唱會舉辦後才可以新增歌曲 - HoverCard
        - (演唱會已舉辦&&未登入) 登入後才能新增歌曲喔！- AlertDialog，替換掉原本的 checkLogin (SweetAlert)
        - (演唱會已舉辦&&已登入) 打開 Dialog
    - 未舉辦的演唱會不顯示歌曲

7. ConcertView.vue
    - 新增已結束 Badge
    - 點擊收藏按鈕：
        - (未登入) 提示需登入 - AlertDialog

8. hooks/useTimeCountryFilter.js
    - 後台演唱會篩選會共用此函式，topic 改為判斷前後台

9. stores/concert
    - callSaveAction 移除 useDarkAlert
    - 新增 searchAdminConcerts：後台演唱會搜尋功能
    - 新增 getAdminConcerts：後台取得演唱會，演唱會排序為 id 大到小，方便 demo 展示

10. stores/user
    - 新增登出功能 adminLogout，登出後轉至前台首頁

11. ui 元件 AlertDialogAction
    - 刪除白字預設

12. ui 元件 Badge
    - 更改基礎樣式：py-0.5 → py-[0.2px]、text-sm → text-tiny、移除 font-semibold
