### PR TITLE
fix: 🐛 換頁元件修復、圖片瀏覽器相容

### DIFF
--- a/src/stores/concerts.js
+++ b/src/stores/concerts.js
@@ -22,6 +22,7 @@ export const useConcertsStore = defineStore('concerts', {
       timeFactor: '',
       countryFactor: '',
       textFactor: '',
+      pageFactor: 1,
     };
   },
   actions: {
@@ -52,6 +53,7 @@ export const useConcertsStore = defineStore('concerts', {
       // 全部按鈕帶空字串，其他按鈕帶該字
       if (filterFactor === 'time') rangeFactor === 'all' ? (this.timeFactor = '') : (this.timeFactor = rangeFactor);
       if (filterFactor === 'country') rangeFactor === 'all' ? (this.countryFactor = '') : (this.countryFactor = rangeFactor);
+      this.pageFactor = page;
 
       timeCountryFilter('front', this.timeFactor, this.countryFactor, this.textFactor, page).then((data) => {
         this.concerts = data.data;
@@ -93,7 +95,6 @@ export const useConcertsStore = defineStore('concerts', {
       // 全部按鈕帶空字串，其它按鈕帶該字
       if (filterFactor === 'time') rangeFactor === '全部' ? (this.timeFactor = '') : (this.timeFactor = rangeFactor);
       if (filterFactor === 'country') rangeFactor === '全部' ? (this.countryFactor = '') : (this.countryFactor = rangeFactor);
-
       this.pageFactor = page;
 
       timeCountryFilter('admin', this.timeFactor, this.countryFactor, this.textFactor, this.pageFactor).then((data) => {

--- a/src/views/front/ArtistsView.vue
+++ b/src/views/front/ArtistsView.vue
@@ -38,8 +38,9 @@
               <p class="text-base lg:text-lg">{{ artist.name }}</p>
               <div class="flex gap-3">
                 <p class="text-tiny text-black-40">{{ artist.follower_count }} fans</p>
-                <p class="text-tiny text-black-60">{{ artist.concert_count }} concerts</p>
+                <p class="text-tiny text-black-60 hidden xs:block">{{ artist.concert_count }} concerts</p>
               </div>
+              <p class="text-tiny text-black-60 block xs:hidden">{{ artist.concert_count }} concerts</p>
               <!-- <div class="pr-3">
                 <p class="text-base lg:text-lg">{{ artist.name }}</p>
                 <p class="text-tiny text-black-60">{{ artist.follower_count }} fans</p>

--- a/src/views/front/ConcertsView.vue
+++ b/src/views/front/ConcertsView.vue
@@ -63,7 +63,7 @@
           <Card class="border-black-80">
             <CardHeader class="rounded-t-2xl space-y-0 p-0">
               <router-link :to="`/concerts/${concert.id}`">
-                <img :src="concert.cover_urls.square" :alt="concert.title" class="brightness-90 aspect-square rounded-2xl object-cover min-w-full" />
+                <img :src="concert.cover_urls.square" :alt="concert.title" class="brightness-90 h-[18rem] xs:h-[26rem] sm:h-[20rem] md:h-[15rem] lg:h-[20rem] rounded-2xl object-cover min-w-full" />
               </router-link>
               <CardDescription class="h-[8rem] sm:h-[10rem] md:h-[13rem] lg:h-[12rem] border-x-2 pt-6 px-6 border-black-80 flex justify-between align-top">
                 <div>
@@ -81,7 +81,7 @@
                   <font-awesome-icon v-else icon="fa-regular fa-bookmark" class="text-3xl ml-4 text-[var(--pink)] hover:translate-y-[-.25rem]" />
                 </button>
                 <AlertDialog>
-                  <AlertDialogTrigger class="flex">
+                  <AlertDialogTrigger class="flex mb-auto">
                     <button v-if="AccessToken === undefined">
                       <font-awesome-icon icon="fa-regular fa-bookmark" class="text-3xl ml-4 text-[var(--pink)] hover:translate-y-[-.25rem]" />
                     </button>
@@ -113,22 +113,22 @@
         </li>
       </ul>
       <!-- Pagination -->
-      <Pagination v-slot="{ page }" :total="pagination.total_pages * 10" :sibling-count="1" show-edges :default-page="1">
+      <Pagination v-slot="page" :page="pageFactor" :total="pagination2.total_pages * 10" :sibling-count="1" show-edges :default-page="1">
         <PaginationList v-slot="{ items }" class="flex items-center justify-center gap-1 pt-16">
           <PaginationFirst @click="getFilterConcerts('', '', 1)" />
-          <PaginationPrev @click="getFilterConcerts('', '', pagination.current_page - 1)" />
+          <PaginationPrev @click="getFilterConcerts('', '', pagination2.current_page - 1)" />
 
           <template v-for="(item, index) in items">
             <PaginationListItem v-if="item.type === 'page'" :key="index" :value="item.value" as-child>
-              <Button class="w-10 h-10 p-0" :variant="item.value === page ? 'default' : 'outline'" @click="getFilterConcerts('', '', index + 1)">
+              <Button class="w-10 h-10 p-0" :variant="page === item.value ? 'default' : 'outline'" @click="getFilterConcerts('', '', index + 1)" :disabled="pageFactor === item.value">
                 {{ item.value }}
               </Button>
             </PaginationListItem>
             <PaginationEllipsis v-else :key="item.type" :index="index" />
           </template>
 
-          <PaginationNext @click="getFilterConcerts('', '', pagination.current_page + 1)" />
-          <PaginationLast @click="getFilterConcerts('', '', pagination.total_pages)" />
+          <PaginationNext @click="getFilterConcerts('', '', pagination2.current_page + 1)" />
+          <PaginationLast @click="getFilterConcerts('', '', pagination2.total_pages)" />
         </PaginationList>
       </Pagination>
     </main>
@@ -185,13 +185,17 @@ export default {
     },
   },
   computed: {
-    ...mapState(useConcertsStore, ['concerts', 'pagination', 'toastActive', 'pagination']),
+    ...mapState(useConcertsStore, ['concerts', 'pagination', 'toastActive', 'pagination', 'pageFactor']),
     ...mapState(useUserStore, ['AccessToken', 'savedConcerts']),
 
     isSaved() {
       return [...this.savedConcerts];
     },
+    pagination2() {
+      return this.pagination;
+    },
   },
+  watch: {},
   mounted() {
     this.getAllConcerts();
 

--- a/src/views/front/VenuesView.vue
+++ b/src/views/front/VenuesView.vue
@@ -18,7 +18,7 @@
           <Card class="border-black-80">
             <CardHeader class="rounded-t-2xl space-y-0 p-0">
               <RouterLink :to="`/venues/${venue.id}`">
-                <img :src="venue.picture.square" :alt="venue.title" class="brightness-90 aspect-square rounded-2xl object-cover min-w-full" />
+                <img :src="venue.picture.square" :alt="venue.title" class="brightness-90 aspect-square rounded-2xl h-[18rem] xs:h-[26rem] sm:h-[20rem] md:h-[15rem] lg:h-[20rem] object-cover min-w-full" />
               </RouterLink>
               <CardTitle class="border-x-2 pt-6 px-6 border-black-80 text-base lg:text-lg">
                 <RouterLink :to="`/venues/${venue.id}`">


### PR DESCRIPTION
1. 修復演唱會頁面換頁元件

2. 修復總覽演唱會/場地圖片瀏覽器相容問題
- 寫死寬高
- 問題：Firefox 瀏覽器圖片高度會跳掉