### PR TITLE
fix: 🐛 修改搜尋選項與取得整體資料

### DIFF
--- a/src/hooks/useTimeCountryFilter.js
+++ b/src/hooks/useTimeCountryFilter.js
@@ -32,7 +32,6 @@ export default () => {
       http
         .get(lastPath)
         .then((res) => {
-          // console.log(res);
           state = res.data;
           resolve(state);
         })

--- a/src/stores/concerts.js
+++ b/src/stores/concerts.js
@@ -35,6 +35,9 @@ export const useConcertsStore = defineStore('concerts', {
       this.getFilterAdminConcerts();
     }, 300),
     getAllConcerts() {
+      this.timeFactor = '';
+      this.countryFactor = '';
+      this.textFactor = '';
       setIsLoading();
       http
         .get(path.concerts)

--- a/src/views/admin/AdminConcertsView.vue
+++ b/src/views/admin/AdminConcertsView.vue
@@ -401,7 +401,7 @@ export default {
       http
         .post(topicPath, { ...this.tempConcert })
         .then((res) => {
-          this.getAllAdminConcerts();
+          this.getFilterAdminConcerts();
           toast({
             title: `演唱會${this.dialogTopic === 'add' ? '新增' : '編輯'}成功`,
           });


### PR DESCRIPTION
後台演唱會
問題點：新增/編輯/刪除等動作後會重新取得所有演唱會，但篩選選項仍保留著。
修改：取得篩選後的演唱會。

前台演唱會
問題點：切頁後回到原頁仍保留篩選後結果。
修改：清空篩選選項，取得所有演唱會。