### PR TITLE
fix: 🐛 換歌單-iframe影響網址

### DIFF
--- a/src/views/front/ConcertSingleView.vue
+++ b/src/views/front/ConcertSingleView.vue
@@ -133,6 +133,8 @@
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen
           @onload="onYouTubeIframeAPIReady()"
+          referrerpolicy="strict-origin-when-cross-origin"
+          :key="ytId"
           v-if="ytId && hasHold"></iframe>
         <div v-else class="flex justify-center items-center text-center text-sm">
           <img :src="singleConcert.cover_urls?.square" alt="演唱會圖片" class="rounded-[20px] w-[336px] h-[336px] object-cover" />


### PR DESCRIPTION
未設立獨立 key 值，導致切換歌曲 url 帶進 iframe 時會影響到路由紀錄