### PR TITLE
fix: 🐛 送出修改時 input 顯示驗證錯誤文字

### DIFF
--- a/src/views/admin/AdminConcertsView.vue
+++ b/src/views/admin/AdminConcertsView.vue
@@ -375,10 +375,6 @@ export default {
       this.tempConcert.sales_time = `${this.tempConcert.salesDate} ${this.tempConcert.salesTime}:00`;
       this.tempConcert.organizers = this.tempConcert.organizerList?.split(',');
 
-      ['priceList', 'holdingDate', 'holdingTime', 'salesDate', 'salesTime', 'organizerList'].forEach((item) => {
-        delete this.tempConcert[item];
-      });
-
       if (this.tempConcert.foreignUrl0 || this.tempConcert.foreignUrl1 || this.tempConcert.foreignUrl2) {
         this.tempConcert.foreign_urls = [];
         for (let i = 0; i < 3; i++) {
@@ -388,7 +384,6 @@ export default {
               url: this.tempConcert[`foreignUrl${i}`]?.split(',')[1],
             });
           }
-          delete this.tempConcert[`foreignUrl${i}`];
         }
       }
 


### PR DESCRIPTION
送出修改進入 loading 時保留 input 文字內容，避免顯示出驗證錯誤文字